### PR TITLE
Fix for issue #3

### DIFF
--- a/MainModInfo.cs
+++ b/MainModInfo.cs
@@ -178,14 +178,7 @@ namespace CKAN
         private void _UpdateModDependencyGraph()
         {
             var module = (CkanModule) ModInfoTabControl.Tag;
-            if (module == dependencyGraphRootModule)
-            {
-                return;
-            }
-            else
-            {
-                dependencyGraphRootModule = module;
-            }
+            dependencyGraphRootModule = module;
 
 
             if (ModuleRelationshipType.SelectedIndex == -1)


### PR DESCRIPTION
Fixes issue #3

The check the method was doing was unnecessary, I tested with both normal modules and with a module that has a circular dependency and no issues where found.

Could not write a unit test as _UpdateModDependencyGraph is too tightly coupled to the UI to run through a NUnit test.
