### PR TITLE
Catch the DirectoryNotFoundKraken raised by PR KSP-CKAN/CKAN-core#18.

### DIFF
--- a/MainInstall.cs
+++ b/MainInstall.cs
@@ -353,6 +353,11 @@ namespace CKAN
                     // User notified in InstallList
                     return false;
                 }
+                catch (DirectoryNotFoundKraken kraken)
+                {
+                    GUI.user.RaiseMessage("\n{0}", kraken.Message);
+                    return false;
+                }
             }
 
             return true;


### PR DESCRIPTION
Does nothing without PR KSP-CKAN/CKAN-core#18

related to KSP-CKAN/CKAN-core#3 and KSP-CKAN/CKAN-core#5
