### PR TITLE
Modify repositories.config to have consistent line endings

### DIFF
--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,5 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <repositories>
+  <repository path="../packages.config" />
+  <repository path="../Tests/packages.config" />
   <repository path="..\packages.config" />
   <repository path="..\Tests\packages.config" />
 </repositories>


### PR DESCRIPTION
Changed line endings from a mix of CRLF and LF to LF, so git no longer should be confused by the file.

For anyone working in windows, git should automatically convert LF to CRLF as far as I understand, so it should not change their workflow in any way.