### PR TITLE
Fixed error in YesNoDialog

### DIFF
--- a/MainDialogs.cs
+++ b/MainDialogs.cs
@@ -31,7 +31,7 @@ namespace CKAN
 
         public bool YesNoDialog(string text)
         {
-            return m_YesNoDialog.ShowYesNoDialog(text) == DialogResult.OK;
+            return m_YesNoDialog.ShowYesNoDialog(text) == DialogResult.Yes;
         }
     }
 }


### PR DESCRIPTION
When returning a result the function compared the DialogResult with `OK` when it should have been comparing it to `Yes`.

Because of this bug the prompt to associate the program with ckan:// url links always assumed you pressed no.