### PR TITLE
URL Registration nolonger displays the GUI as an admin.

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace CKAN
@@ -21,7 +22,18 @@ namespace CKAN
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionEventHandler;
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            new Main(args, user, showConsole);
+
+            if (args.Contains(URLHandlers.UrlRegistrationArgument))
+            {
+                //Passing in null will cause a NullRefrenceException if it tries to show the dialog 
+                //asking for elevation permission, but we want that to happen. Doing that keeps us 
+                //from getting in to a infinite loop of trying to register.
+                URLHandlers.RegisterURLHandler(null, null); 
+            }
+            else
+            {
+                new Main(args, user, showConsole);
+            }
         }
 
         public static void UnhandledExceptionEventHandler(Object sender, UnhandledExceptionEventArgs e)

--- a/URLHandlers.cs
+++ b/URLHandlers.cs
@@ -40,7 +40,7 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
                             // we need elevation to write to the registry
                             ProcessStartInfo startInfo = new ProcessStartInfo(System.Reflection.Assembly.GetEntryAssembly().Location);
                             startInfo.Verb = "runas"; // trigger a UAC prompt (if UAC is enabled)
-                            startInfo.Arguments = UrlRegistrationArgument;
+                            startInfo.Arguments = "gui " + UrlRegistrationArgument;
                             Process.Start(startInfo);
                         }
                         else

--- a/URLHandlers.cs
+++ b/URLHandlers.cs
@@ -11,6 +11,7 @@ namespace CKAN
     public static class URLHandlers
     {
         private static readonly ILog log = LogManager.GetLogger(typeof(URLHandlers));
+        public const string UrlRegistrationArgument = "registerUrl";
 
         public static void RegisterURLHandler(Configuration config, IUser user)
         {
@@ -39,8 +40,8 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
                             // we need elevation to write to the registry
                             ProcessStartInfo startInfo = new ProcessStartInfo(System.Reflection.Assembly.GetEntryAssembly().Location);
                             startInfo.Verb = "runas"; // trigger a UAC prompt (if UAC is enabled)
+                            startInfo.Arguments = UrlRegistrationArgument;
                             Process.Start(startInfo);
-                            Environment.Exit(0);
                         }
                         else
                         {


### PR DESCRIPTION
URL Registration will now instead of closing the current instance and launching the entire GUI as an admin will now leave the current instance open and silently open a hidden instance that just performs the registration and closes.