### PR TITLE
Fix dialog size of KSPCommandLine on Linux.

### DIFF
--- a/KSPCommandLineOptionsDialog.cs
+++ b/KSPCommandLineOptionsDialog.cs
@@ -3,11 +3,13 @@
 namespace CKAN
 {
 
-    public partial class KSPCommandLineOptionsDialog : Form
+    public partial class KSPCommandLineOptionsDialog : FormCompatibility
     {
         public KSPCommandLineOptionsDialog()
         {
             InitializeComponent();
+            ApplyFormCompatibilityFixes();
+
             StartPosition = FormStartPosition.CenterScreen;
         }
 


### PR DESCRIPTION
The dialog for the KSP command line options did not have the right window size on Linux. Changed the class to use the same fixes fixes as other dialog windows.