### PR TITLE
Change restart behavior when selecting another KSP instance.

### DIFF
--- a/SettingsDialog.cs
+++ b/SettingsDialog.cs
@@ -84,8 +84,11 @@ namespace CKAN
         {
             Main.Instance.Manager.ClearAutoStart();
 
-            Process.Start(System.Reflection.Assembly.GetExecutingAssembly().Location);
-            Application.Exit();
+            ProcessStartInfo sinfo = new ProcessStartInfo(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            sinfo.UseShellExecute = false;
+
+            Process.Start(sinfo);
+            Environment.Exit(0);
         }
 
         private void ReposListBox_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
Changes the way CKAN restarts itself when selecting a new instance using the GUI. The old way should be sufficient, but has some issues as apparent in https://github.com/KSP-CKAN/CKAN-support/issues/2.

This changes they way the new CKAN instance is spawned, and the way the old CKAN instance is stopped. Needs testing Windows/OS X, and perhaps someone with a deeper understanding of .Net can explain why this change is necessary in the first place.

Closes https://github.com/KSP-CKAN/CKAN-support/issues/2.