### PR TITLE
Ckan support issue 2 permissions fix

### DIFF
--- a/SettingsDialog.cs
+++ b/SettingsDialog.cs
@@ -91,7 +91,7 @@ namespace CKAN
                 string command = string.Format("+x \"{0}\"", System.Reflection.Assembly.GetExecutingAssembly().Location);
 
                 ProcessStartInfo permsinfo = new ProcessStartInfo("chmod", command);
-                permsinfo.UseShellExecute = true;
+                permsinfo.UseShellExecute = false;
 
                 // Execute the command.
                 Process permsprocess = Process.Start(permsinfo);

--- a/SettingsDialog.cs
+++ b/SettingsDialog.cs
@@ -84,6 +84,28 @@ namespace CKAN
         {
             Main.Instance.Manager.ClearAutoStart();
 
+            // Mono throws an uninformative error if the file we try to run is not flagged as executable, mark it as such.
+            if (Util.IsLinux)
+            {
+                // Create the command with the filename of the currently running assembly.
+                string command = string.Format("+x \"{0}\"", System.Reflection.Assembly.GetExecutingAssembly().Location);
+
+                ProcessStartInfo permsinfo = new ProcessStartInfo("chmod", command);
+                permsinfo.UseShellExecute = true;
+
+                // Execute the command.
+                Process permsprocess = Process.Start(permsinfo);
+
+                // Wait for chmod to finish and check the exit code.
+                permsprocess.WaitForExit();
+
+                // chmod returns 0 for successfull operation.
+                if (permsprocess.ExitCode != 0)
+                {
+                    throw new Kraken("Could not mark CKAN as executable.");
+                }
+            }
+
             ProcessStartInfo sinfo = new ProcessStartInfo(System.Reflection.Assembly.GetExecutingAssembly().Location);
             sinfo.UseShellExecute = false;
 


### PR DESCRIPTION
It turns out that Mono gives the noninformative error of
```System.ComponentModel.Win32Exception: ApplicationName='/path/ckan.exe', CommandLine='', CurrentDirectory='', Native error= Cannot find the specified file```
when trying to start a new process with a file that is not marked as executable. This will always run a ```chmod +x``` on the executing CKAN assembly to circumvent this error.

Should be the final fix for https://github.com/KSP-CKAN/CKAN-support/issues/2.