### PR TITLE
Added check for nunit-console.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,9 +19,9 @@ check_nunit () {
 xbuild /verbosity:minimal CKAN-GUI.sln
 
 # Find a suitable version of nunit.
-declare -a VERSIONS=("nunit-console" "nunit-console4")
+declare -a NUNIT_VERSIONS=("nunit-console" "nunit-console4")
 
-for i in "${VERSIONS[@]}"
+for i in "${NUNIT_VERSIONS[@]}"
 do
     echo "Checking if $i is available..."
     command -v "$i" >/dev/null 2>&1 && check_nunit $i

--- a/build.sh
+++ b/build.sh
@@ -19,13 +19,11 @@ check_nunit () {
 xbuild /verbosity:minimal CKAN-GUI.sln
 
 # Find a suitable version of nunit.
-declare -a NUNIT_VERSIONS=("nunit-console" "nunit-console4")
+echo "Checking if nunit-console is available..."
+command -v "nunit-console" >/dev/null 2>&1 && check_nunit "nunit-console"
 
-for i in "${NUNIT_VERSIONS[@]}"
-do
-    echo "Checking if $i is available..."
-    command -v "$i" >/dev/null 2>&1 && check_nunit $i
-done
+echo "Checking if nunit-console4 is available..."
+command -v "nunit-console4" >/dev/null 2>&1 && check_nunit "nunit-console4"
 
 # If we found a suitable nunit binary, continue with the testing.
 if [ "$NUNIT_BINARY" != "" ]

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,36 @@
 #!/bin/bash
 set -x
 
+NUNIT_BINARY=""
+
+check_nunit () {
+    # Extract the CLR version of nunit-console.
+    NUNIT_TEXT=$($1 -help)
+    NUNIT_VERSION=$(echo "$NUNIT_TEXT" | awk '$1 ~ /CLR/ {print substr($3,1,1)}')
+    
+    if [ $NUNIT_VERSION -eq 4 ]
+    then
+        NUNIT_BINARY=$1
+    fi
+    
+    echo "Found $1 with CLR version $NUNIT_VERSION."
+}
+
 xbuild /verbosity:minimal CKAN-GUI.sln
-nunit-console --exclude=FlakyNetwork Tests/bin/Debug/Tests.dll
-# prove
+
+# Find a suitable version of nunit.
+declare -a VERSIONS=("nunit-console" "nunit-console4")
+
+for i in "${VERSIONS[@]}"
+do
+    echo "Checking if $i is available..."
+    command -v "$i" >/dev/null 2>&1 && check_nunit $i
+done
+
+# If we found a suitable nunit binary, continue with the testing.
+if [ "$NUNIT_BINARY" != "" ]
+then
+    command $NUNIT_BINARY --exclude=FlakyNetwork Tests/bin/Debug/Tests.dll
+else
+    echo "Could not find a suitable version of nunit-console to run the tests. Skipping test execution."
+fi

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -x
 
 NUNIT_BINARY=""


### PR DESCRIPTION
On some Linux systems nunit-console is linked to CLR version 2 where we need CLR version 4. This checks the CLR version of nunint-console and nunit-console4. If they are not found, or not the right CLR version, the testing step is skipped.

Part of the solution for https://github.com/KSP-CKAN/CKAN-support/issues/106.