### PR TITLE
Add space as a toggle for current mod.

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -347,10 +347,29 @@ namespace CKAN
 
         /// <summary>
         /// Called on key press when the mod is focused. Scrolls to the first mod 
-        /// with name begining with the key pressed. 
+        /// with name begining with the key pressed. If space is pressed, the checkbox
+        /// at the current row is toggled.
         /// </summary>        
         private void ModList_KeyPress(object sender, KeyPressEventArgs e)
         {
+            // Check the key. If it is space, mark the current mod as selected.
+            if (e.KeyChar.ToString() == " ")
+            {
+                var selectedRow = ModList.CurrentRow;
+
+                if (selectedRow != null)
+                {
+                    // Get the checkbox.
+                    var selectedRowCheckBox = (DataGridViewCheckBoxCell)selectedRow.Cells["Installed"];
+
+                    // Invert the value.
+                    bool selectedValue = (bool)selectedRowCheckBox.Value;
+                    selectedRowCheckBox.Value = !selectedValue;
+                }
+
+                return;
+            }
+
             var rows = ModList.Rows.Cast<DataGridViewRow>().Where(row => row.Visible);
             var does_name_begin_with_char = new Func<DataGridViewRow, bool>(row =>
             {


### PR DESCRIPTION
https://github.com/KSP-CKAN/CKAN-support/issues/120 suggests adding a key for toggling the installed flag for the mods in the GUI list. This changeset adds this behavior to the space key, as I would expect enter to apply the currently selected changeset (Which is for another PR to do).

Closes https://github.com/KSP-CKAN/CKAN-support/issues/120.