### PR TITLE
Fix navigation keys in gridview.

### DIFF
--- a/CKAN-GUI.csproj
+++ b/CKAN-GUI.csproj
@@ -226,6 +226,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <Compile Include="Controls\KSPDataGridView.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -277,5 +278,8 @@
       <ProductName>Windows Installer 4.5</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Controls\" />
   </ItemGroup>
 </Project>

--- a/Controls/KSPDataGridView.cs
+++ b/Controls/KSPDataGridView.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Windows.Forms;
+
+namespace CKAN
+{
+    public class KSPDataGridView : System.Windows.Forms.DataGridView
+    {
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            switch (e.KeyData & e.KeyCode)
+            {
+                case Keys.Down:
+                    SelectNextVisibleRow();
+                    break;
+                case Keys.Up:
+                    SelectPreviousVisibleRow();
+                    break;
+                case Keys.Space:
+                    ToggleCurrentSelection();
+                    break;
+                default:
+                    base.OnKeyDown(e);
+                    return;
+            }
+
+            // Wo do not want anyone else to handle this event.
+            e.Handled = true;
+            e.SuppressKeyPress = true;
+        }
+
+        /// <summary>
+        /// Gets the index of the currently selected row, or -1 if none is selected.
+        /// </summary>
+        /// <returns>The current index.</returns>
+        private int GetCurrentIndex()
+        {
+            // Check for null.
+            if (this.SelectedRows == null)
+            {
+                return -1;
+            }
+            if (this.SelectedRows[0] == null)
+            {
+                return -1;
+            }
+
+            // Get the currently selected row.
+            return this.SelectedRows[0].Index;
+        }
+
+        /// <summary>
+        /// Selects the next visible row.
+        /// </summary>
+        private void SelectNextVisibleRow()
+        {
+            // Get the currently selected row.
+            int index = GetCurrentIndex();
+
+            if (index < 0)
+            {
+                return;
+            }
+
+            // Do a boundary check.
+            if (index == this.Rows.Count - 1)
+            {
+                return;
+            }
+
+            // Look for the next visible row.
+            for (int i = index + 1; i < this.Rows.Count; i++)
+            {
+                if (this.Rows[i].Visible)
+                {
+                    // Deselect the current row.
+                    this.Rows[index].Selected = false;
+
+                    // Select the visible row.
+                    this.Rows[i].Selected = true;
+
+                    UpdateScroll();
+
+                    return;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Selects the previous visible row.
+        /// </summary>
+        private void SelectPreviousVisibleRow()
+        {
+            // Get the currently selected row.
+            int index = GetCurrentIndex();
+
+            if (index < 0)
+            {
+                return;
+            }
+
+            // Look for the previous visible row.
+            for (int i = index - 1; i >= 0; i--)
+            {
+                if (this.Rows[i].Visible)
+                {
+                    // Deselect the current row.
+                    this.Rows[index].Selected = false;
+
+                    // Select the visible row.
+                    this.Rows[i].Selected = true;
+
+                    UpdateScroll();
+
+                    return;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Toggles the checkbox of the current row.
+        /// </summary>
+        private void ToggleCurrentSelection()
+        {
+            // Get the currently selected row.
+            int index = GetCurrentIndex();
+
+            if (index < 0)
+            {
+                return;
+            }
+
+            // Get the checkbox.
+            var selectedRowCheckBox = (DataGridViewCheckBoxCell)this.Rows[index].Cells["Installed"];
+
+            // Invert the value.
+            bool selectedValue = (bool)selectedRowCheckBox.Value;
+            selectedRowCheckBox.Value = !selectedValue;
+        }
+
+        /// <summary>
+        /// Update the scroll view to include the currently selected row.
+        /// </summary>
+        private void UpdateScroll()
+        {
+            // Need some help with this one.
+
+            /*
+            // Get the currently selected row.
+            int index = GetCurrentIndex();
+
+            if (index < 0)
+            {
+                return;
+            }
+
+            // Check if we are in the view.
+            int startRow = this.FirstDisplayedScrollingRowIndex;
+            int displayedRows = this.DisplayedRowCount(false);
+
+            int currentRow = startRow + 1;
+            int finalRow = 0;
+            int foundRows = 0;
+
+            // We need to keep in mind the invisible rows.
+            do
+            {
+                // Check if we have reached the end.
+                if (currentRow >= this.Rows.Count)
+                {
+                    break;
+                }
+
+                // Is this item visible?
+                if(this.Rows[currentRow].Visible)
+                {
+                    foundRows++;
+                    finalRow = currentRow;
+                }
+
+                // Increment the index.
+                currentRow++;
+            } while (foundRows < displayedRows);
+
+            // Is the current row within the bounds?
+            if (index > startRow && index < finalRow)
+            {
+                // Do nothing, we are visible.
+                return;
+            }
+            else
+            {
+                // Move the startindex to this element.
+                this.FirstDisplayedScrollingRowIndex = index;
+                this.Update();
+            }*/
+        }
+    }
+}

--- a/Main.Designer.cs
+++ b/Main.Designer.cs
@@ -1269,7 +1269,7 @@ namespace CKAN
         private DataGridViewLinkColumn Homepage;
         private ToolStripMenuItem pluginsToolStripMenuItem;
         public ToolStripMenuItem settingsToolStripMenuItem;
-        public DataGridView ModList;
+        public KSPDataGridView ModList;
         private ToolStripMenuItem installFromckanToolStripMenuItem;
     }
 }

--- a/Main.Designer.cs
+++ b/Main.Designer.cs
@@ -55,7 +55,7 @@ namespace CKAN
             this.FilterNotInstalledButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterIncompatibleButton = new System.Windows.Forms.ToolStripMenuItem();
             this.customToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.ModList = new System.Windows.Forms.DataGridView();
+            this.ModList = new KSPDataGridView();
             this.Installed = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.Update = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.ModName = new System.Windows.Forms.DataGridViewTextBoxColumn();

--- a/Main.cs
+++ b/Main.cs
@@ -362,39 +362,12 @@ namespace CKAN
             DataGridViewRow match = rows.FirstOrDefault(does_name_begin_with_char);
             if (match != null)
             {
+                // Make sure the matching row is selected.
                 match.Selected = true;
 
-                if (Util.IsLinux)
-                {
-                    try
-                    {
-
-                        var first_row_index = ModList.GetType().GetField("first_row_index",
-                            BindingFlags.NonPublic | BindingFlags.Instance);
-                        var vertical_scroll_bar = ModList.GetType().GetField("verticalScrollBar",
-                            BindingFlags.NonPublic | BindingFlags.Instance).GetValue(ModList);
-                        var safe_set_method = vertical_scroll_bar.GetType().GetMethod("SafeValueSet",
-                            BindingFlags.NonPublic | BindingFlags.Instance);
-
-                        first_row_index.SetValue(ModList, match.Index);
-                        safe_set_method.Invoke(vertical_scroll_bar,
-                            new object[] { match.Index * match.Height });
-                    }
-                    catch
-                    {
-                        //Compared to crashing ignoring the keypress is fine.
-                    }
-                    ModList.FirstDisplayedScrollingRowIndex = match.Index;
-                    ModList.Refresh();
-                }
-                else
-                {
-                    //Not the best of names. Why not FirstVisableRowIndex?
-                    ModList.FirstDisplayedScrollingRowIndex = match.Index;
-                }
+                // Update the scroll position.
+                ModList.UpdateScroll();
             }
-
-
         }
 
         /// <summary>

--- a/Main.cs
+++ b/Main.cs
@@ -347,29 +347,10 @@ namespace CKAN
 
         /// <summary>
         /// Called on key press when the mod is focused. Scrolls to the first mod 
-        /// with name begining with the key pressed. If space is pressed, the checkbox
-        /// at the current row is toggled.
+        /// with name beginning with the key pressed.
         /// </summary>        
         private void ModList_KeyPress(object sender, KeyPressEventArgs e)
         {
-            // Check the key. If it is space, mark the current mod as selected.
-            if (e.KeyChar.ToString() == " ")
-            {
-                var selectedRow = ModList.CurrentRow;
-
-                if (selectedRow != null)
-                {
-                    // Get the checkbox.
-                    var selectedRowCheckBox = (DataGridViewCheckBoxCell)selectedRow.Cells["Installed"];
-
-                    // Invert the value.
-                    bool selectedValue = (bool)selectedRowCheckBox.Value;
-                    selectedRowCheckBox.Value = !selectedValue;
-                }
-
-                return;
-            }
-
             var rows = ModList.Rows.Cast<DataGridViewRow>().Where(row => row.Visible);
             var does_name_begin_with_char = new Func<DataGridViewRow, bool>(row =>
             {


### PR DESCRIPTION
As reported in https://github.com/KSP-CKAN/CKAN-support/issues/119 the arrow keys do not work properly for the gridview. I have resorted to implement a subclass of DataGridView to handle the keys. I am not 100 % sure of the implementation, as it assumes the rows are always sorted.

I also rolled in the fix for https://github.com/KSP-CKAN/CKAN-support/issues/120 into this commit instead, as it fits better here. Sorry @RichardLake for having to push the last fix.

There is still an unresolved issue with scrolling. The code I have attempted to use in order to get it to work is included.

Closes https://github.com/KSP-CKAN/CKAN-support/issues/119.