### PR TITLE
Fix for crash when unchecking installed mod

### DIFF
--- a/MainModList.cs
+++ b/MainModList.cs
@@ -211,7 +211,9 @@ namespace CKAN
             foreach (var reverseDependencies in modulesToRemove.Select(mod => installer.FindReverseDependencies(mod)))
             {
                 //TODO This would be a good place to have a event that alters the row's graphics to show it will be removed
-                var modules = reverseDependencies.Select(rDep => registry.LatestAvailable(rDep, current_instance.Version()));
+
+                //TODO This currently gets the latest version. This may cause the displayed version to wrong in the changset. 
+                var modules = reverseDependencies.Select(rDep => registry.LatestAvailable(rDep, null));
                 changeset.UnionWith(
                     modules.Select(mod => new KeyValuePair<CkanModule, GUIModChangeType>(mod, GUIModChangeType.Remove)));
             }


### PR DESCRIPTION
Closes KSP-CKAN/CKAN#832
It is only a quick fix but trying to do it properly caused me to run into issues with CkanModules vs Modules vs Strings. Attempting to standardise lead to issues with the lack of equals or hash-code in Modules etc. 
Long story short it seems worthwhile to do this as a quick fix and the other stuff as separate pull requests when I get around to them. 