### PR TITLE
Wrap auto updater call in a try catch.

### DIFF
--- a/AskUserForAutoUpdatesDialog.Designer.cs
+++ b/AskUserForAutoUpdatesDialog.Designer.cs
@@ -56,7 +56,7 @@
             // 
             // button1
             // 
-            this.button1.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.button1.DialogResult = System.Windows.Forms.DialogResult.No;
             this.button1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button1.Location = new System.Drawing.Point(323, 44);
             this.button1.Name = "button1";

--- a/Main.cs
+++ b/Main.cs
@@ -181,22 +181,29 @@ namespace CKAN
 
             if (m_Configuration.CheckForUpdatesOnLaunch)
             {
-                var latestVersion = AutoUpdate.FetchLatestCkanVersion();
-                var currentVersion = new Version(Meta.Version());
-
-                if (latestVersion.IsGreaterThan(currentVersion))
+                try
                 {
-                    var releaseNotes = AutoUpdate.FetchLatestCkanVersionReleaseNotes();
-                    var dialog = new NewUpdateDialog(latestVersion.ToString(), releaseNotes);
-                    if (dialog.ShowDialog() == DialogResult.OK)
+                    var latest_version = AutoUpdate.FetchLatestCkanVersion();
+                    var current_version = new Version(Meta.Version());
+
+                    if (latest_version.IsGreaterThan(current_version))
                     {
-                        AutoUpdate.StartUpdateProcess(true);
+                        var release_notes = AutoUpdate.FetchLatestCkanVersionReleaseNotes();
+                        var dialog = new NewUpdateDialog(latest_version.ToString(), release_notes);
+                        if (dialog.ShowDialog() == DialogResult.OK)
+                        {
+                            AutoUpdate.StartUpdateProcess(true);
+                        }
                     }
                 }
+                catch (Exception exception)
+                {
+                    m_User.RaiseError("Error in autoupdate: \n\t"+exception.Message +"");                    
+                }      
             }
 
-            this.Location = m_Configuration.WindowLoc;
-            this.Size = m_Configuration.WindowSize;
+            Location = m_Configuration.WindowLoc;
+            Size = m_Configuration.WindowSize;
 
             m_UpdateRepoWorker = new BackgroundWorker {WorkerReportsProgress = false, WorkerSupportsCancellation = true};
 


### PR DESCRIPTION
Before this any exception from it would be silently ignored by the event handler and the rest of Main_Load would not be run.
This causes major issues with the GUI - no mods in mod list. Null Referance when attempting to refresh and so on.