### PR TITLE
Replace Util.IsLinux with calls to Platform.is{} methods

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -31,7 +31,9 @@ namespace CKAN
                 var configuration = new Configuration
                 {
                     m_Path = path,
-                    CommandLineArguments = Util.IsLinux ? "./KSP.x86_64" : "KSP.exe"
+                    CommandLineArguments = Platform.IsUnix ? "./KSP.x86_64" :
+                                           Platform.IsMac  ? "./KSP.app/Contents/MacOS/KSP" :
+                                                             "KSP.exe"
                 };
 
                 SaveConfiguration(configuration, path);

--- a/FormCompatibility.cs
+++ b/FormCompatibility.cs
@@ -11,7 +11,7 @@ namespace CKAN
 
         public void ApplyFormCompatibilityFixes()
         {
-            if (Util.IsLinux)
+            if (!Platform.IsWindows)
             {
                 ClientSize = new Size(ClientSize.Width, ClientSize.Height + formHeightDifference);      
             }

--- a/Main.cs
+++ b/Main.cs
@@ -387,8 +387,8 @@ namespace CKAN
             if (match != null)
             {
                 match.Selected = true;
-
-                if (Util.IsLinux)
+                //Assume that no one is running via mono on windows
+                if (!Platform.IsWindows)
                 {
                     try
                     {

--- a/SettingsDialog.cs
+++ b/SettingsDialog.cs
@@ -90,7 +90,7 @@ namespace CKAN
             Main.Instance.Manager.ClearAutoStart();
 
             // Mono throws an uninformative error if the file we try to run is not flagged as executable, mark it as such.
-            if (Util.IsLinux)
+            if (!Platform.IsWindows)
             {
                 // Create the command with the filename of the currently running assembly.
                 string command = string.Format("+x \"{0}\"", System.Reflection.Assembly.GetExecutingAssembly().Location);

--- a/URLHandlers.cs
+++ b/URLHandlers.cs
@@ -17,11 +17,11 @@ namespace CKAN
         {
             try
             {
-                if (Util.IsLinux)
+                if (Platform.IsUnix)
                 {
                     RegisterURLHandler_Linux();
                 }
-                else
+                else if(Platform.IsWindows)
                 {
                     try
                     {
@@ -51,6 +51,8 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
                         
                         throw;
                     }
+                } else if (Platform.IsMac) {
+                    //TODO
                 }
             }
             catch (Exception ex)

--- a/Util.cs
+++ b/Util.cs
@@ -7,27 +7,9 @@ namespace CKAN
     using System.Windows.Forms;
 
     public static class Util
-    {
-        
-        public static bool IsLinux
-        {
-            get
-            {
-                // Magic numbers ahoy! This arcane incantation was found
-                // in a Unity help-page, which was found on a scroll,
-                // which was found in an urn that dated back to Mono 2.0.
-                // It documents singular numbers of great power.
-                //
-                // "And lo! 'pon the 4, 6, and 128 the penguin shall
-                // come, and it infiltrate dominate from the smallest phone to
-                // the largest cloud."
-                int p = (int)Environment.OSVersion.Platform;
-                return (p == 4) || (p == 6) || (p == 128);
-            }
-        }
-
+    {                
         /// <summary>
-        /// Invokes an actin on the UI thread, or directly if we're
+        /// Invokes an action on the UI thread, or directly if we're
         /// on the UI thread.
         /// </summary>
         public static void Invoke<T>(T obj, Action action) where T : Control
@@ -71,7 +53,7 @@ namespace CKAN
 
         public static void HideConsoleWindow()
         {
-            if (!IsLinux)
+            if (Platform.IsWindows)
             {
                 ShowWindow(GetConsoleWindow(), 0);
             }


### PR DESCRIPTION
Also fix the OSX start up argument - it doesn't have a x64 version and calebmennen reported a mono issue workaround.