### PR TITLE
Test update: GUI shows compatible modules by default.

### DIFF
--- a/Tests/GUI/MainModList.cs
+++ b/Tests/GUI/MainModList.cs
@@ -11,7 +11,7 @@ namespace Tests.GUI
         public void OnCreation_HasDefaultFilters()
         {
             var item = new MainModList(delegate { });
-            Assert.AreEqual(GUIModFilter.All, item.ModFilter, "ModFilter");
+            Assert.AreEqual(GUIModFilter.Compatible, item.ModFilter, "ModFilter");
             Assert.AreEqual(String.Empty, item.ModNameFilter, "ModNameFilter");
         }
 


### PR DESCRIPTION
Our previous test checked to see if *all* modules were shown, but
now we can filter by compatibility, the compatible list is indeed
the correct default.