### PR TITLE
Workarounds for KSP-CKAN/CKAN#760, UI quirks on OS X

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -63,6 +63,8 @@ namespace CKAN
 
         public GUIUser m_User = null;
 
+        private Timer filterTimer = null;
+
         private IEnumerable<KeyValuePair<CkanModule, GUIModChangeType>> change_set;
         private Dictionary<Module, string> conflicts;
 
@@ -421,12 +423,44 @@ namespace CKAN
 
         private void FilterByNameTextBox_TextChanged(object sender, EventArgs e)
         {
-            mainModList.ModNameFilter = FilterByNameTextBox.Text;
+            RunFilterUpdateTimer();
         }
 
         private void FilterByAuthorTextBox_TextChanged(object sender, EventArgs e)
         {
+            RunFilterUpdateTimer();
+        }
+
+        /// <summary>
+        /// Start or updatea timer to update the filter after an interval 
+        /// since the last keypress.
+        /// </summary>
+        private void RunFilterUpdateTimer() {
+            if (filterTimer == null)
+            {
+                filterTimer = new Timer();
+                filterTimer.Tick += OnFilterUpdateTimer;
+                filterTimer.Interval = 700;
+                filterTimer.Start();
+            }
+            else
+            {
+                filterTimer.Stop();
+                filterTimer.Start();
+            }
+        }
+
+        /// <summary>
+        /// Updates the filter after an interval of time has passed since the 
+        /// last keypress. On Mac OS X, this prevents the search field from locking up.
+        /// </summary>
+        /// <param name="source">Source.</param>
+        /// <param name="e">E.</param>
+        private void OnFilterUpdateTimer(Object source, EventArgs e)
+        {
+            mainModList.ModNameFilter = FilterByNameTextBox.Text;
             mainModList.ModAuthorFilter = FilterByAuthorTextBox.Text;
+            filterTimer.Stop();
         }
 
         /// <summary>

--- a/Main.cs
+++ b/Main.cs
@@ -423,17 +423,36 @@ namespace CKAN
 
         private void FilterByNameTextBox_TextChanged(object sender, EventArgs e)
         {
-            RunFilterUpdateTimer();
+            if (Platform.IsMac)
+            {
+                // Delay updating to improve typing performance on OS X
+                RunFilterUpdateTimer();
+            }
+            else
+            {
+                mainModList.ModNameFilter = FilterByNameTextBox.Text;
+            }
         }
 
         private void FilterByAuthorTextBox_TextChanged(object sender, EventArgs e)
         {
-            RunFilterUpdateTimer();
+            if (Platform.IsMac)
+            {
+                // Delay updating to improve typing performance on OS X
+                RunFilterUpdateTimer();
+            }
+            else
+            {
+                mainModList.ModAuthorFilter = FilterByAuthorTextBox.Text;
+            }
         }
 
         /// <summary>
-        /// Start or updatea timer to update the filter after an interval 
-        /// since the last keypress.
+        /// Start or restart a timer to update the filter after an interval 
+        /// since the last keypress. On Mac OS X, this prevents the search 
+        /// field from locking up due to DataGridViews being slow and
+        /// key strokes being interpreted incorrectly when slowed down:
+        /// http://mono.1490590.n4.nabble.com/Incorrect-missing-and-duplicate-keypress-events-td4658863.html
         /// </summary>
         private void RunFilterUpdateTimer() {
             if (filterTimer == null)
@@ -452,10 +471,10 @@ namespace CKAN
 
         /// <summary>
         /// Updates the filter after an interval of time has passed since the 
-        /// last keypress. On Mac OS X, this prevents the search field from locking up.
+        /// last keypress.
         /// </summary>
-        /// <param name="source">Source.</param>
-        /// <param name="e">E.</param>
+        /// <param name="source">Source</param>
+        /// <param name="e">EventArgs</param>
         private void OnFilterUpdateTimer(Object source, EventArgs e)
         {
             mainModList.ModNameFilter = FilterByNameTextBox.Text;

--- a/TabController.cs
+++ b/TabController.cs
@@ -100,7 +100,6 @@ namespace CKAN
             {
                 index = m_TabControl.TabPages.Count;
             }
-          
 
             m_TabControl.TabPages.Insert(index, m_TabPages[name]);
 
@@ -139,34 +138,37 @@ namespace CKAN
             {
                 args.Cancel = true;
             }
-            else if (args.Action == TabControlAction.Deselecting)
-            {
-                // Have to set visibility to false on children controls on hidden tabs because they don't 
-                // always heed parent visibility on Mac OS X https://bugzilla.xamarin.com/show_bug.cgi?id=3124
-                foreach (Control control in args.TabPage.Controls)
+            else if (Platform.IsMac)
+            { 
+                if (args.Action == TabControlAction.Deselecting)
                 {
-                    control.Visible = false;
-                }
-            }
-            else if (args.Action == TabControlAction.Selecting)
-            {
-                // Set children controls' visibility back to true
-                foreach (Control control in args.TabPage.Controls)
-                {
-                    control.Visible = true;
-
-                    // Have to specifically tell the mod list's panel to refresh
-                    // after things settle out because otherwise it doesn't 
-                    // when coming back to the mods tab from updating the repo
-                    if (control is SplitContainer)
+                    // Have to set visibility to false on children controls on hidden tabs because they don't 
+                    // always heed parent visibility on Mac OS X https://bugzilla.xamarin.com/show_bug.cgi?id=3124
+                    foreach (Control control in args.TabPage.Controls)
                     {
-                        Task.Factory.StartNew(
-                            () =>
-                            {
-                                Thread.Sleep(300);
+                        control.Visible = false;
+                    }
+                }
+                else if (args.Action == TabControlAction.Selecting)
+                {
+                    // Set children controls' visibility back to true
+                    foreach (Control control in args.TabPage.Controls)
+                    {
+                        control.Visible = true;
 
-                                ((SplitContainer)control).Panel1.Refresh();
-                            });
+                        // Have to specifically tell the mod list's panel to refresh
+                        // after things settle out because otherwise it doesn't 
+                        // when coming back to the mods tab from updating the repo
+                        if (control is SplitContainer)
+                        {
+                            Task.Factory.StartNew(
+                                () =>
+                                {
+                                    Thread.Sleep(300);
+
+                                    ((SplitContainer)control).Panel1.Refresh();
+                                });
+                        }
                     }
                 }
             }

--- a/TabController.cs
+++ b/TabController.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Windows.Forms;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace CKAN
 {
@@ -98,6 +100,7 @@ namespace CKAN
             {
                 index = m_TabControl.TabPages.Count;
             }
+          
 
             m_TabControl.TabPages.Insert(index, m_TabPages[name]);
 
@@ -135,6 +138,37 @@ namespace CKAN
             if (m_TabLock)
             {
                 args.Cancel = true;
+            }
+            else if (args.Action == TabControlAction.Deselecting)
+            {
+                // Have to set visibility to false on children controls on hidden tabs because they don't 
+                // always heed parent visibility on Mac OS X https://bugzilla.xamarin.com/show_bug.cgi?id=3124
+                foreach (Control control in args.TabPage.Controls)
+                {
+                    control.Visible = false;
+                }
+            }
+            else if (args.Action == TabControlAction.Selecting)
+            {
+                // Set children controls' visibility back to true
+                foreach (Control control in args.TabPage.Controls)
+                {
+                    control.Visible = true;
+
+                    // Have to specifically tell the mod list's panel to refresh
+                    // after things settle out because otherwise it doesn't 
+                    // when coming back to the mods tab from updating the repo
+                    if (control is SplitContainer)
+                    {
+                        Task.Factory.StartNew(
+                            () =>
+                            {
+                                Thread.Sleep(300);
+
+                                ((SplitContainer)control).Panel1.Refresh();
+                            });
+                    }
+                }
             }
         }
 

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -1,17 +1,14 @@
 #!/bin/bash
 set -x
 
-xbuild /verbosity:minimal CKAN-GUI.sln
+#Run the CMD build.sh
+cd ../CKAN-cmdline
+./build.sh
+cd ../CKAN-GUI
 
-if [ -d "./bin/Debug/CKAN.app/" ]; then
-  rm -rf "./bin/Debug/CKAN.app"
+if [ -d "../CKAN.app/" ]; then
+  rm -rf "../CKAN.app"
 fi
-macpack -m:1 -o:bin/Debug/ \
+macpack -m:1 -o:../ \
   -i:assets/ckan.icns \
-  -r:bin/Debug/CKAN.dll \
-  -r:bin/Debug/ChinhDo.Transactions.dll \
-  -r:bin/Debug/ICSharpCode.SharpZipLib.dll \
-  -r:bin/Debug/INIFileParser.dll \
-  -r:bin/Debug/Newtonsoft.Json.dll \
-  -r:bin/Debug/log4net.dll \
-  -n:CKAN -a:bin/Debug/CKAN-GUI.exe
+  -n:CKAN -a:../ckan.exe


### PR DESCRIPTION
These don't totally address the issues described in KSP-CKAN/CKAN#760 but they mitigate the biggest ones. At their core the issues are deeply ingrained in the OSX WinForms implementation, which isn't really maintained, unfortunately.

 **Filter text field**
I added a timer to Main which keeps the mod filters from being updated until after the user stops typing, to mitigate the issue where you can only type one letter every 2 seconds.
 

**Tab redraw**
TabController now manually sets the visibility of controls in tabs when they are selected and deselected. It also manually refreshes the mod list SplitContainer since something draws over top of it when switching back to the mod list tab after refreshing repositories. This mostly fixes things drawing on the wrong tab, but not entirely; particularly, list views don't seem to stop drawing even when their visibility is false, and it also doesn't do anything to views that are children of children of a tab.

That fix assumes that tabs don't rely on visibility staying constant when they are deselected and then selected again.
 
**Other Notes**
Both those workarounds are only running on OS X (which requires the fix in my other pull request to actually work).
 

Unrelatedly, I also updated the build_mac.sh script to wrap the ckan.exe file rather than CKAN-GUI.exe, so that it works with plugins which I assume reference ckan.exe by name. Could have just renamed the GUI exe but that may have been confusing.

Thanks! Hopefully that wasn't too verbose, let me know if you have any feedback. :)