### PR TITLE
ChooseKspInstall#860

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -299,7 +299,7 @@ namespace CKAN
 
             ModList.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.AllCells);
 
-            Text = String.Format("CKAN {0} - KSP {1}", Meta.Version(), CurrentInstance.Version());
+            Text = String.Format("CKAN {0} - KSP {1}    --    {2}", Meta.Version(), CurrentInstance.Version(), CurrentInstance.GameDir());
             KSPVersionLabel.Text = String.Format("Kerbal Space Program {0}", CurrentInstance.Version());
 
             if (m_CommandLineArgs.Length >= 2)

--- a/Main.cs
+++ b/Main.cs
@@ -295,12 +295,11 @@ namespace CKAN
             URLHandlers.RegisterURLHandler(m_Configuration, m_User);
             m_User.displayYesNo = null;
 
-            ApplyToolButton.Enabled = false;
+            ApplyToolButton.Enabled = false;            
+
+            CurrentInstanceUpdated();
 
             ModList.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.AllCells);
-
-            Text = String.Format("CKAN {0} - KSP {1}    --    {2}", Meta.Version(), CurrentInstance.Version(), CurrentInstance.GameDir());
-            KSPVersionLabel.Text = String.Format("Kerbal Space Program {0}", CurrentInstance.Version());
 
             if (m_CommandLineArgs.Length >= 2)
             {
@@ -341,6 +340,25 @@ namespace CKAN
             }
 
             m_PluginController = new PluginController(pluginsPath, true);
+        }
+
+        public void CurrentInstanceUpdated()
+        {
+            Util.Invoke(this, () =>
+            {
+                Text = String.Format("CKAN {0} - KSP {1}    --    {2}", Meta.Version(), CurrentInstance.Version(),
+                CurrentInstance.GameDir());
+                KSPVersionLabel.Text = String.Format("Kerbal Space Program {0}", CurrentInstance.Version());
+
+            });
+            m_Configuration = Configuration.LoadOrCreateConfiguration
+            (
+                Path.Combine(CurrentInstance.GameDir(), "CKAN/GUIConfig.xml"),
+                Repo.default_ckan_repo.ToString()
+            );
+            UpdateModsList();
+            ChangeSet = null;
+            Conflicts = null;
         }
 
         private void RefreshToolButton_Click(object sender, EventArgs e)

--- a/SettingsDialog.cs
+++ b/SettingsDialog.cs
@@ -88,34 +88,10 @@ namespace CKAN
         private void ResetAutoStartChoice_Click(object sender, EventArgs e)
         {
             Main.Instance.Manager.ClearAutoStart();
-
-            // Mono throws an uninformative error if the file we try to run is not flagged as executable, mark it as such.
-            if (!Platform.IsWindows)
-            {
-                // Create the command with the filename of the currently running assembly.
-                string command = string.Format("+x \"{0}\"", System.Reflection.Assembly.GetExecutingAssembly().Location);
-
-                ProcessStartInfo permsinfo = new ProcessStartInfo("chmod", command);
-                permsinfo.UseShellExecute = false;
-
-                // Execute the command.
-                Process permsprocess = Process.Start(permsinfo);
-
-                // Wait for chmod to finish and check the exit code.
-                permsprocess.WaitForExit();
-
-                // chmod returns 0 for successfull operation.
-                if (permsprocess.ExitCode != 0)
-                {
-                    throw new Kraken("Could not mark CKAN as executable.");
-                }
-            }
-
-            ProcessStartInfo sinfo = new ProcessStartInfo(System.Reflection.Assembly.GetExecutingAssembly().Location);
-            sinfo.UseShellExecute = false;
-
-            Process.Start(sinfo);
-            Environment.Exit(0);
+            var old_instance = Main.Instance.CurrentInstance;
+            var result = new ChooseKSPInstance().ShowDialog();
+            if(!Equals(old_instance, Main.Instance.CurrentInstance))
+                Main.Instance.CurrentInstanceUpdated();            
         }
 
         private void ReposListBox_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
Instead of clearing the autostart and restarting the program just change the current instance.
Fixes KSP-CKAN/CKAN#860 which was introduced in 003f15a5b.