### PR TITLE
Tweaks to the workaround for KSP-CKAN/CKAN#760

### DIFF
--- a/TabController.cs
+++ b/TabController.cs
@@ -140,7 +140,7 @@ namespace CKAN
             }
             else if (Platform.IsMac)
             { 
-                if (args.Action == TabControlAction.Deselecting)
+                if (args.Action == TabControlAction.Deselecting && args.TabPage != null)
                 {
                     // Have to set visibility to false on children controls on hidden tabs because they don't 
                     // always heed parent visibility on Mac OS X https://bugzilla.xamarin.com/show_bug.cgi?id=3124
@@ -149,7 +149,7 @@ namespace CKAN
                         control.Visible = false;
                     }
                 }
-                else if (args.Action == TabControlAction.Selecting)
+                else if (args.Action == TabControlAction.Selecting && args.TabPage != null)
                 {
                     // Set children controls' visibility back to true
                     foreach (Control control in args.TabPage.Controls)

--- a/TabController.cs
+++ b/TabController.cs
@@ -164,7 +164,7 @@ namespace CKAN
                             Task.Factory.StartNew(
                                 () =>
                                 {
-                                    Thread.Sleep(300);
+                                    Thread.Sleep(500);
 
                                     ((SplitContainer)control).Panel1.Refresh();
                                 });


### PR DESCRIPTION
Tweaks the workaround I submitted yesterday for the OS X glitches in KSP-CKAN/CKAN#760 -- give the mod list a little more time to finish loading up before redrawing it, and avoid crashing when the tab being Selected or Deselected is null (which apparently can happen when a tab is removed).