### PR TITLE
Initial workaround for slow download on OSX, KSP-CKAN/CKAN#840.

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -199,7 +199,30 @@ namespace CKAN
             // Disable the modinfo controls until a mod has been choosen.
             this.ModInfoTabControl.Enabled = false;
 
+            // WinForms on Mac OS X has a nasty bug where the UI thread hogs the CPU,
+            // making our download speeds really slow unless you move the mouse while 
+            // downloading. Yielding periodically addresses that.
+            // https://bugzilla.novell.com/show_bug.cgi?id=663433
+            if (Platform.IsMac)
+            {
+                System.Windows.Forms.Timer yieldTimer = new System.Windows.Forms.Timer();
+                yieldTimer.Interval = 2;
+                yieldTimer.Tick += YieldTimer_Tick;
+                yieldTimer.Start();
+            }
+
             Application.Run(this);
+        }
+
+        /// <summary>
+        /// Used above to fix the UI thread from hogging all the CPU on OS X,
+        /// slowing down downloads.
+        /// </summary>
+        /// <param name="sender">Sender.</param>
+        /// <param name="e">E.</param>
+        void YieldTimer_Tick (object sender, EventArgs e)
+        {
+            System.Threading.Thread.Yield();
         }
 
         private void ModList_CurrentCellDirtyStateChanged(object sender, EventArgs e)


### PR DESCRIPTION
As in this issue: https://bugzilla.novell.com/show_bug.cgi?id=663433 in OSX on WinForms threads run faster while the mouse is moving?
  
By adding a WinForms timer that just yields to other threads really frequently this issue seems to be mitigated a bit.

Downloads are now ~x10 as fast for me, but still a lot slower than the CLI, and slower than it can go by moving the mouse really fast. Doesn't seem to impact the UI's performance.

Not sure if there's a way to attack this from the side of the download thread instead.