### PR TITLE
Update Configuration.cs to work with non-standard taskbar placement

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -26,7 +26,7 @@ namespace CKAN
             {
                 if (m_window_loc.X < 0 && m_window_loc.Y < 0)
                 {
-                    m_window_loc = new Point(0, 0);
+                    m_window_loc = new Point(60, 30);
                 }
                 return m_window_loc;
             }


### PR DESCRIPTION
This is a very selfish enhancement which probably have an effects very few users. But it does affect me!

When setting the mainwindowpos to 0, 0 the GUI clashes with a sidemounted taskbar in windows like [so](http://i.imgur.com/SNVEXwB.png). By manually setting the mainwindowpos to 60, 0 I managed to circumvent this problem.

If you instead have the taskbar at the top the problem gets worse since it then blocks the ability to move the GUI if the taskbar isn't locked. Setting mainwindowpos to 60, 30 when something broke fixes both of these cases.

I'm not sure if something else needs changing aswell, I took inspiration from https://github.com/KSP-CKAN/CKAN-GUI/pull/100 and have close to zero idea of what I'm doing :)