### PR TITLE
Refresh settings dialog upon update.

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -386,8 +386,14 @@ namespace CKAN
                 Text = String.Format("CKAN {0} - KSP {1}    --    {2}", Meta.Version(), CurrentInstance.Version(),
                 CurrentInstance.GameDir());
                 KSPVersionLabel.Text = String.Format("Kerbal Space Program {0}", CurrentInstance.Version());
-
             });
+
+            // Update the settings dialog to reflect the changes made.
+            Util.Invoke(this.m_SettingsDialog, () =>
+            {
+                this.m_SettingsDialog.UpdateDialog();
+            });
+
             m_Configuration = Configuration.LoadOrCreateConfiguration
             (
                 Path.Combine(CurrentInstance.GameDir(), "CKAN/GUIConfig.xml"),

--- a/SettingsDialog.cs
+++ b/SettingsDialog.cs
@@ -17,6 +17,11 @@ namespace CKAN
 
         private void SettingsDialog_Load(object sender, EventArgs e)
         {
+            UpdateDialog();
+        }
+
+        public void UpdateDialog()
+        {
             RefreshReposListBox();
 
             KSPInstallPathLabel.Text = Main.Instance.CurrentInstance.GameDir();


### PR DESCRIPTION
When switching instances, the new way of not closing the UI leaves the settings dialog in an inconsistent state.

I'm not 100% sure on the way invoke works, so pinging @RichardLake for a check on this (Thread safety and all).