### PR TITLE
Have user select provides

### DIFF
--- a/App.config
+++ b/App.config
@@ -3,9 +3,9 @@
     <configSections>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
     </startup>
   <runtime>
-    <loadFromRemoteSources enabled="true" />
+    <loadFromRemoteSources enabled="true"/>
   </runtime>
 </configuration>

--- a/CKAN-GUI.csproj
+++ b/CKAN-GUI.csproj
@@ -27,6 +27,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>

--- a/ErrorDialog.Designer.cs
+++ b/ErrorDialog.Designer.cs
@@ -29,7 +29,7 @@
         private void InitializeComponent()
         {
             this.panel1 = new System.Windows.Forms.Panel();
-            this.ErrorMessage = new System.Windows.Forms.Label();
+            this.ErrorMessage = new System.Windows.Forms.RichTextBox();
             this.DismissButton = new System.Windows.Forms.Button();
             this.panel1.SuspendLayout();
             this.SuspendLayout();
@@ -50,7 +50,7 @@
             this.ErrorMessage.Size = new System.Drawing.Size(267, 117);
             this.ErrorMessage.TabIndex = 0;
             this.ErrorMessage.Text = "Error!";
-            this.ErrorMessage.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.ErrorMessage.ReadOnly = true;
             // 
             // DismissButton
             // 
@@ -82,7 +82,7 @@
         #endregion
 
         private System.Windows.Forms.Panel panel1;
-        private System.Windows.Forms.Label ErrorMessage;
+        private System.Windows.Forms.RichTextBox ErrorMessage;
         private System.Windows.Forms.Button DismissButton;
     }
 }

--- a/Main.Designer.cs
+++ b/Main.Designer.cs
@@ -1143,7 +1143,9 @@ namespace CKAN
             this.ChooseProvidedModsListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeader6,
             this.columnHeader8});
+            this.ChooseProvidedModsListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
             this.ChooseProvidedModsListView.Location = new System.Drawing.Point(6, 28);
+            this.ChooseProvidedModsListView.MultiSelect = false;
             this.ChooseProvidedModsListView.Name = "ChooseProvidedModsListView";
             this.ChooseProvidedModsListView.Size = new System.Drawing.Size(1007, 582);
             this.ChooseProvidedModsListView.TabIndex = 8;
@@ -1183,7 +1185,7 @@ namespace CKAN
             this.MainMenuStrip = this.menuStrip1;
             this.MinimumSize = new System.Drawing.Size(878, 664);
             this.Name = "Main";
-            this.Text = "CKAN-GUI";            
+            this.Text = "CKAN-GUI";
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.menuStrip2.ResumeLayout(false);

--- a/Main.cs
+++ b/Main.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using CKAN.Properties;
 using log4net;
@@ -75,8 +76,9 @@ namespace CKAN
             get { return change_set; }
             set
             {
+                var orig = change_set;
                 change_set = value;
-                ChangeSetUpdated();
+                if(!ReferenceEquals(orig, value)) ChangeSetUpdated();
             }
         }
 
@@ -85,8 +87,9 @@ namespace CKAN
             get { return conflicts; }
             set
             {
+                var orig = conflicts;
                 conflicts = value;
-                ConflictsUpdated();
+                if(orig != value) ConflictsUpdated();
             }
         }
 
@@ -401,6 +404,7 @@ namespace CKAN
                 var mod = ((GUIMod) row.Tag);
                 if (mod.HasUpdate && row.Cells[1] is DataGridViewCheckBoxCell)
                 {
+                    MarkModForUpdate(mod.Identifier);
                     mod.SetUpgradeChecked(row, true);
                     ApplyToolButton.Enabled = true;
                 }
@@ -508,15 +512,11 @@ namespace CKAN
 
                 if (selected_row != null)
                 {
-                    // Get the checkbox.
-                    var selected_row_check_box = selected_row.Cells["Installed"] as DataGridViewCheckBoxCell;
-
-                    // Invert the value.
-                    if (selected_row_check_box != null)
-                    {
-                        bool selected_value = (bool)selected_row_check_box.Value;
-                        selected_row_check_box.Value = !selected_value;
-                    }                    
+                    var gui_mod = ((GUIMod)selected_row.Tag);
+                    if (gui_mod.IsInstallable())
+                    {                        
+                        MarkModForInstall(gui_mod.Identifier,uninstall:gui_mod.IsInstallChecked);                        
+                    }                                         
                 }
                 e.Handled = true;
                 return;
@@ -547,7 +547,7 @@ namespace CKAN
             ModList.CommitEdit(DataGridViewDataErrorContexts.Commit);
         }
 
-        private void ModList_CellValueChanged(object sender, DataGridViewCellEventArgs e)
+        private async void ModList_CellValueChanged(object sender, DataGridViewCellEventArgs e)
         {
             if (mainModList.ModFilter == GUIModFilter.Incompatible)
             {
@@ -574,11 +574,12 @@ namespace CKAN
             }
             else if (column_index < 2)
             {
-                var gui_mod = ((GUIMod) row.Tag);
+                var gui_mod = ((GUIMod)row.Tag);
                 switch (column_index)
                 {
                     case 0:
                         gui_mod.SetInstallChecked(row);
+                        last_mod_to_have_install_toggled = gui_mod.IsInstallChecked ? gui_mod : last_mod_to_have_install_toggled;
                         break;
                     case 1:
                         gui_mod.SetUpgradeChecked(row);
@@ -586,11 +587,11 @@ namespace CKAN
                 }
 
                 var registry = registry_manager.registry;
-                UpdateChangeSetAndConflicts(registry);
+                await UpdateChangeSetAndConflicts(registry);
             }
         }
 
-        private async void UpdateChangeSetAndConflicts(Registry registry)
+        private async Task UpdateChangeSetAndConflicts(Registry registry)
         {
             IEnumerable<KeyValuePair<CkanModule, GUIModChangeType>> full_change_set;
             Dictionary<Module, string> conflicts;
@@ -599,8 +600,9 @@ namespace CKAN
             try
             {
                 var module_installer = ModuleInstaller.GetInstance(CurrentInstance, GUI.user);
-                full_change_set = await mainModList.ComputeChangeSetFromModList(registry, user_change_set, module_installer,
-                    CurrentInstance.Version());
+                full_change_set =
+                    await mainModList.ComputeChangeSetFromModList(registry, user_change_set, module_installer,
+                        CurrentInstance.Version());
                 conflicts = null;
             }
             catch (InconsistentKraken)
@@ -609,6 +611,14 @@ namespace CKAN
                 user_change_set = mainModList.ComputeUserChangeSet();
                 conflicts = MainModList.ComputeConflictsFromModList(registry, user_change_set, CurrentInstance.Version());
                 full_change_set = null;
+            }
+            catch (TooManyModsProvideKraken)
+            {
+                //Can be thrown by ComputeChangeSetFromModList if the user cancels out of it.
+                //We can just rerun it as the ModInfoTabControl has been removed.
+                await UpdateChangeSetAndConflicts(registry);
+                conflicts = Conflicts;
+                full_change_set = ChangeSet;
             }
 
             Conflicts = conflicts;

--- a/Main.cs
+++ b/Main.cs
@@ -155,7 +155,7 @@ namespace CKAN
 
             controlFactory = new ControlFactory();
             Instance = this;
-            mainModList = new MainModList(source => UpdateFilters(this), TooManyModsProvide);
+            mainModList = new MainModList(source => UpdateFilters(this), TooManyModsProvide, User);
             InitializeComponent();
 
             // We need to initialize error dialog first to display errors

--- a/Main.cs
+++ b/Main.cs
@@ -579,7 +579,8 @@ namespace CKAN
                 {
                     case 0:
                         gui_mod.SetInstallChecked(row);
-                        last_mod_to_have_install_toggled = gui_mod.IsInstallChecked ? gui_mod : last_mod_to_have_install_toggled;
+                        if(gui_mod.IsInstallChecked)
+                            last_mod_to_have_install_toggled.Push(gui_mod);
                         break;
                     case 1:
                         gui_mod.SetUpgradeChecked(row);

--- a/Main.cs
+++ b/Main.cs
@@ -152,7 +152,7 @@ namespace CKAN
 
             controlFactory = new ControlFactory();
             Instance = this;
-            mainModList = new MainModList(source => UpdateFilters(this));
+            mainModList = new MainModList(source => UpdateFilters(this), TooManyModsProvide);
             InitializeComponent();
 
             // We need to initialize error dialog first to display errors
@@ -590,7 +590,7 @@ namespace CKAN
             }
         }
 
-        private void UpdateChangeSetAndConflicts(Registry registry)
+        private async void UpdateChangeSetAndConflicts(Registry registry)
         {
             IEnumerable<KeyValuePair<CkanModule, GUIModChangeType>> full_change_set;
             Dictionary<Module, string> conflicts;
@@ -599,12 +599,14 @@ namespace CKAN
             try
             {
                 var module_installer = ModuleInstaller.GetInstance(CurrentInstance, GUI.user);
-                full_change_set = MainModList.ComputeChangeSetFromModList(registry, user_change_set, module_installer,
+                full_change_set = await mainModList.ComputeChangeSetFromModList(registry, user_change_set, module_installer,
                     CurrentInstance.Version());
                 conflicts = null;
             }
             catch (InconsistentKraken)
             {
+                //Need to be recomputed due to ComputeChangeSetFromModList possibly changing it with too many provides handling.
+                user_change_set = mainModList.ComputeUserChangeSet();
                 conflicts = MainModList.ComputeConflictsFromModList(registry, user_change_set, CurrentInstance.Version());
                 full_change_set = null;
             }

--- a/Main.cs
+++ b/Main.cs
@@ -621,7 +621,7 @@ namespace CKAN
                 conflicts = Conflicts;
                 full_change_set = ChangeSet;
             }
-
+            last_mod_to_have_install_toggled.Clear();
             Conflicts = conflicts;
             ChangeSet = full_change_set;
         }

--- a/MainDialogs.cs
+++ b/MainDialogs.cs
@@ -1,11 +1,11 @@
 ﻿using System;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace CKAN
 {
     public partial class Main
     {
-
         private ErrorDialog m_ErrorDialog;
         private SettingsDialog m_SettingsDialog;
         private PluginsDialog m_PluginsDialog;
@@ -32,6 +32,32 @@ namespace CKAN
         public bool YesNoDialog(string text)
         {
             return m_YesNoDialog.ShowYesNoDialog(text) == DialogResult.Yes;
+        }
+
+        
+        private async Task<CkanModule> TooManyModsProvide(TooManyModsProvideKraken kraken)
+        {            
+            TaskCompletionSource<CkanModule> task = new TaskCompletionSource<CkanModule>();
+            Util.Invoke(this, () =>
+            {
+                UpdateProvidedModsDialog(kraken, task);
+                m_TabController.ShowTab("ChooseProvidedModsTabPage", 3);
+                m_TabController.SetTabLock(true);
+            });
+            var module = await task.Task;
+            
+
+            Util.Invoke(this, () =>
+            {
+                m_TabController.SetTabLock(false);
+
+                m_TabController.HideTab("ChooseProvidedModsTabPage");
+
+                m_TabController.ShowTab("ManageModsTabPage");
+            });
+
+            MarkModForInstall(module.identifier);
+            return module;
         }
     }
 }

--- a/MainInstall.cs
+++ b/MainInstall.cs
@@ -436,12 +436,7 @@ namespace CKAN
 
         private void ChooseProvidedModsCancelButton_Click(object sender, EventArgs e)
         {
-            installCanceled = true;
-
-            lock (this)
-            {
-                Monitor.Pulse(this);
-            }
+            toomany_source.SetResult(null);
         }
 
         private void ChooseProvidedModsContinueButton_Click(object sender, EventArgs e)

--- a/MainInstall.cs
+++ b/MainInstall.cs
@@ -407,7 +407,7 @@ namespace CKAN
 
             foreach (CkanModule module in tooManyProvides.modules)
             {
-                ListViewItem item = new ListViewItem {Tag = module, Checked = true, Text = module.name};
+                ListViewItem item = new ListViewItem {Tag = module, Checked = false, Text = module.name};
 
 
                 ListViewItem.ListViewSubItem description =
@@ -416,14 +416,17 @@ namespace CKAN
                 item.SubItems.Add(description);
                 ChooseProvidedModsListView.Items.Add(item);
             }
+            ChooseProvidedModsContinueButton.Enabled = false;
         }
 
         private void ChooseProvidedModsListView_ItemChecked(object sender, ItemCheckedEventArgs e)
         {
             if (!e.Item.Checked)
             {
+                ChooseProvidedModsContinueButton.Enabled = false;
                 return;
             }
+            ChooseProvidedModsContinueButton.Enabled = true;
 
             foreach (ListViewItem item in ChooseProvidedModsListView.Items)
             {
@@ -432,6 +435,7 @@ namespace CKAN
                     item.Checked = false;
                 }
             }
+            
         }
 
         private void ChooseProvidedModsCancelButton_Click(object sender, EventArgs e)

--- a/MainInstall.cs
+++ b/MainInstall.cs
@@ -416,7 +416,7 @@ namespace CKAN
                 item.SubItems.Add(description);
                 ChooseProvidedModsListView.Items.Add(item);
             }
-            ChooseProvidedModsListView.Invalidate();
+            ChooseProvidedModsListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
             ChooseProvidedModsContinueButton.Enabled = false;
         }
 

--- a/MainInstall.cs
+++ b/MainInstall.cs
@@ -416,6 +416,7 @@ namespace CKAN
                 item.SubItems.Add(description);
                 ChooseProvidedModsListView.Items.Add(item);
             }
+            ChooseProvidedModsListView.Invalidate();
             ChooseProvidedModsContinueButton.Enabled = false;
         }
 

--- a/MainModList.cs
+++ b/MainModList.cs
@@ -110,7 +110,7 @@ namespace CKAN
                     mod.IsInstallChecked = !uninstall;
                     //TODO Fix up MarkMod stuff when I commit the GUIConflict
                     (row.Cells[0] as DataGridViewCheckBoxCell).Value = !uninstall;
-                    if (!uninstall) last_mod_to_have_install_toggled = mod;
+                    if (!uninstall) last_mod_to_have_install_toggled.Push(mod);
                     break;
                 }
             }

--- a/MainModList.cs
+++ b/MainModList.cs
@@ -33,6 +33,7 @@ namespace CKAN
             }
             
             ModList.Rows.AddRange(rows.Where(row => row.Visible).OrderBy(row => ((GUIMod) row.Tag).Name).ToArray());
+            ConflictsUpdated(); //Reapply the conflict graphics
         }
 
         private void UpdateModsList(Boolean repo_updated = false)

--- a/Tests/GUI/MainModList.cs
+++ b/Tests/GUI/MainModList.cs
@@ -129,7 +129,8 @@ namespace Tests.GUI
         }
 
         [Test]
-        public void TooManyProvidesCallsHandler()
+        [Category("Display")]
+        public async Task TooManyProvidesCallsHandler()
         {
             using (var tidy = new DisposableKSP())
             {                
@@ -153,11 +154,12 @@ namespace Tests.GUI
                     new KeyValuePair<CkanModule, GUIModChangeType>(mod,GUIModChangeType.Install)
                 };
                     
-                var mod_list = main_mod_list.ComputeChangeSetFromModList(registry, a, installer, null).Result;
+                var mod_list = await main_mod_list.ComputeChangeSetFromModList(registry, a, installer, null);
                 CollectionAssert.AreEquivalent(
                     new [] {
                         new KeyValuePair<CkanModule,GUIModChangeType>(mod,GUIModChangeType.Install),
                         new KeyValuePair<CkanModule,GUIModChangeType>(modb,GUIModChangeType.Install)},mod_list);                
+                        
             }
         }
         

--- a/Tests/GUI/MainModList.cs
+++ b/Tests/GUI/MainModList.cs
@@ -12,7 +12,7 @@ namespace Tests.GUI
         [Test]
         public void OnCreation_HasDefaultFilters()
         {
-            var item = new MainModList(delegate { });
+            var item = new MainModList(delegate { }, delegate { return null; });
             Assert.AreEqual(GUIModFilter.Compatible, item.ModFilter, "ModFilter");
             Assert.AreEqual(String.Empty, item.ModNameFilter, "ModNameFilter");
         }
@@ -21,7 +21,7 @@ namespace Tests.GUI
         public void OnModTextFilterChanges_CallsEventHandler()
         {
             var called_n = 0;
-            var item = new MainModList(delegate { called_n++; });
+            var item = new MainModList(delegate { called_n++; }, delegate { return null; });
             Assert.That(called_n == 1);
             item.ModNameFilter = "randomString";
             Assert.That(called_n == 2);
@@ -32,7 +32,7 @@ namespace Tests.GUI
         public void OnModTypeFilterChanges_CallsEventHandler()
         {
             var called_n = 0;
-            var item = new MainModList(delegate { called_n++; });
+            var item = new MainModList(delegate { called_n++; }, delegate { return null; });
             Assert.That(called_n == 1);
             item.ModFilter = GUIModFilter.Installed;
             Assert.That(called_n == 2);
@@ -46,7 +46,7 @@ namespace Tests.GUI
             using (var tidy = new DisposableKSP())
             {
                 KSPManager manager = new KSPManager(new NullUser(), new FakeWin32Registry(tidy.KSP)) { CurrentInstance = tidy.KSP };
-                var item = new MainModList(delegate { });
+                var item = new MainModList(delegate { }, delegate { return null; });
                 Assert.That(item.ComputeUserChangeSet(), Is.Empty);
             }
         }
@@ -66,7 +66,7 @@ namespace Tests.GUI
                 registry.AddAvailable(TestData.kOS_014_module());
                 registry.RegisterModule(module,Enumerable.Empty<string>(), tidy.KSP );
 
-                var main_mod_list = new MainModList(null);
+                var main_mod_list = new MainModList(null, null);
                 var mod = new GUIMod(TestData.FireSpitterModule(), registry, manager.CurrentInstance.Version());
                 var mod2 = new GUIMod(TestData.kOS_014_module(), registry, manager.CurrentInstance.Version());
                 mod.IsInstallChecked = true;
@@ -76,7 +76,7 @@ namespace Tests.GUI
                     mod,
                     mod2
                 });
-                Assert.Throws<InconsistentKraken>(()=>MainModList.ComputeChangeSetFromModList(registry,main_mod_list.ComputeUserChangeSet(),null, tidy.KSP.Version()));
+                Assert.Throws<InconsistentKraken>(()=>main_mod_list.ComputeChangeSetFromModList(registry,main_mod_list.ComputeUserChangeSet(),null, tidy.KSP.Version()));
             }
         }
 
@@ -90,7 +90,7 @@ namespace Tests.GUI
                 var ckan_mod = TestData.FireSpitterModule();
                 var registry = Registry.Empty();
                 registry.AddAvailable(ckan_mod);
-                var item = new MainModList(delegate { });
+                var item = new MainModList(delegate { }, null);
                 Assert.That(item.IsVisible(new GUIMod(ckan_mod, registry, manager.CurrentInstance.Version())));
             }
         }
@@ -98,7 +98,7 @@ namespace Tests.GUI
         [Test]
         public void CountModsByFilter_EmptyModList_ReturnsZeroForAllFilters()
         {
-            var item = new MainModList(delegate { });
+            var item = new MainModList(delegate { }, null);
             foreach (GUIModFilter filter in Enum.GetValues(typeof(GUIModFilter)))
             {
                 Assert.That(item.CountModsByFilter(filter), Is.EqualTo(0));
@@ -116,7 +116,7 @@ namespace Tests.GUI
                 var registry = Registry.Empty();
                 registry.AddAvailable(TestData.FireSpitterModule());
                 registry.AddAvailable(TestData.kOS_014_module());
-                var main_mod_list = new MainModList(null);
+                var main_mod_list = new MainModList(null, null);
                 var mod_list = main_mod_list.ConstructModList(new List<GUIMod>
                 {
                     new GUIMod(TestData.FireSpitterModule(), registry, manager.CurrentInstance.Version()),

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -7,12 +7,15 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Tests</RootNamespace>
     <AssemblyName>Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CKAN">


### PR DESCRIPTION
Have user select provides when there are multiple choices.

Fixes KSP-CKAN/CKAN#976
Pops up the moment the user chooses a mod instead of waiting until the install. This way there can be accurate change sets and conflict detection.
